### PR TITLE
Add support for Swift package manager

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SnapKit",
+        "repositoryURL": "https://github.com/SnapKit/SnapKit.git",
+        "state": {
+          "branch": null,
+          "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
+          "version": "5.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SnackBar",
+    platforms: [
+        .iOS(.v11)
+    ],
+    products: [
+        .library(name: "SnackBar",
+                 targets: ["SnackBar"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/SnapKit/SnapKit.git", .upToNextMajor(from: "5.0.0"))
+    ],
+    targets: [
+        .target(name: "SnackBar",
+                dependencies: ["SnapKit"],
+                path: "SnackBar.swift"),
+    ],
+    swiftLanguageVersions: [.v5]
+
+)

--- a/README.md
+++ b/README.md
@@ -75,11 +75,23 @@ class AppSnackBar: SnackBar {
 
 ## Installation
 
+### CocoaPods
+
 SnackBar.swift is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
 pod 'SnackBar.swift'
+```
+
+### Swift Package Manager
+
+The [Swift Package Manager](https://swift.org/package-manager/) is a tool for managing the distribution of Swift code. It’s integrated with the Swift build system to automate the process of downloading, compiling, and linking dependencies.
+
+To integrate `SnackBar` into your Xcode project using Xcode 11 or newer, specify it in `File > Swift Packages > Add`:
+
+```
+https://github.com/ahmedAlmasri/SnackBar.swift
 ```
 
 ## Author


### PR DESCRIPTION
Thank you for open sourcing your library!
This PR adds support for Swift package manager so that it's easier to use directly from Xcode.