### PR TITLE
Fix action button content compression

### DIFF
--- a/SnackBar.swift/Classes/SnackBar/SnackBar.swift
+++ b/SnackBar.swift/Classes/SnackBar/SnackBar.swift
@@ -41,6 +41,7 @@ open class SnackBar: UIView, SnackBarAction, SnackBarPresentable {
 	
 	private lazy var actionButton: UIButton = {
 		let actionButton = UIButton(type: .system)
+		actionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
 		actionButton.setContentHuggingPriority(.required, for: .horizontal)
 		actionButton.setTitleColor(
 			style.actionTextColor


### PR DESCRIPTION
When the title text is too large, the action button gets compressed. I think the behavior should be reversed, and that's what my fix does